### PR TITLE
:hammer: Checking if collection has a tag to remove the product count

### DIFF
--- a/snippets/facets.liquid
+++ b/snippets/facets.liquid
@@ -35,7 +35,7 @@
 
         {% if enable_filtering %}
           {% if filter_type == 'vertical'%}
-            {% render 'product-grid-layout-switch', 
+            {% render 'product-grid-layout-switch',
                 layout: "vertical"
             %}
           {% endif %}
@@ -145,7 +145,7 @@
                               <span aria-hidden="true">{{ value.label | escape }} ({{ value.count }})</span>
                               <span class="visually-hidden">{{ value.label | escape }} ({% if value.count == 1 %}{{ 'products.facets.product_count_simple.one' | t: count: value.count }}{% else %}{{ 'products.facets.product_count_simple.other' | t: count: value.count }}{% endif %})</span>
                             </label>
-                          </li> 
+                          </li>
                         {%- endfor -%}
                       </ul>
                       {% comment %} No show more for no JS {% endcomment %}
@@ -182,7 +182,7 @@
                               <span aria-hidden="true">{{ value.label | escape }} ({{ value.count }})</span>
                               <span class="visually-hidden">{{ value.label | escape }} ({% if value.count == 1 %}{{ 'products.facets.product_count_simple.one' | t: count: value.count }}{% else %}{{ 'products.facets.product_count_simple.other' | t: count: value.count }}{% endif %})</span>
                             </label>
-                          </li> 
+                          </li>
                         {%- endfor -%}
                       </ul>
                     </fieldset>
@@ -271,7 +271,7 @@
           </div>
           {% comment %} Pills after filtes on filter type horizontal {% endcomment %}
           {%- if filter_type == 'horizontal' -%}
-            {% render 'product-grid-layout-switch', 
+            {% render 'product-grid-layout-switch',
               layout: "horizontal"
             %}
             <div class="active-facets active-facets-desktop">
@@ -338,6 +338,7 @@
               </noscript>
             </div>
           {%- endif -%}
+          {% unless current_tags %}
           <div class="product-count light" role="status">
             <h2 class="product-count__text text-body">
               <span id="ProductCountDesktop">
@@ -355,7 +356,8 @@
                 <circle class="path" fill="none" stroke-width="6" cx="33" cy="33" r="30"></circle>
               </svg>
             </div>
-          </div>  
+          </div>
+          {% endunless %}
         {%- endif -%}
       </form>
     </facet-filters-form>
@@ -394,7 +396,7 @@
           {%- endif -%}
         </form>
       </facet-filters-form>
-    {%- endif -%}    
+    {%- endif -%}
   {%- endif -%}
   {% comment %}  Drawer and mobile filter {% endcomment %}
   <menu-drawer class="mobile-facets__wrapper{% if filter_type == 'horizontal' or filter_type == 'vertical' %} medium-hide large-up-hide{% endif %}" data-breakpoint="mobile">
@@ -486,7 +488,7 @@
                                   <path d="M1.5 3.5L2.83333 4.75L4.16667 6L9.5 1" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" />
                                 </svg>
 
-                                
+
                                 <span aria-hidden="true">{{ value.label | escape }} ({{ value.count }})</span>
                                 <span class="visually-hidden">{{ value.label | escape }} ({% if value.count == '1' %}{{ 'products.facets.product_count_simple.one' | t: count: value.count }}{% else %}{{ 'products.facets.product_count_simple.other' | t: count: value.count }}{% endif %})</span>
                               </label>
@@ -651,7 +653,7 @@
   </div>
   {% comment %} Sort, product count and filter pills at the end when filter is type of Drawer for the correct tabbing order {% endcomment %}
   {%- if enable_sorting and filter_type == 'drawer' -%}
-      {% render 'product-grid-layout-switch', 
+      {% render 'product-grid-layout-switch',
         layout: "horizontal"
       %}
     <facet-filters-form class="facets small-hide">
@@ -680,7 +682,7 @@
         {% if results.current_vendor or results.current_type %}
           <input type="hidden" name="q" value="{{ results.current_vendor }}{{ results.current_type }}">
         {% endif %}
-    
+
         {%- if results.terms -%}
           <input type="hidden" name="q" value="{{ results.terms | escape }}">
           <input name="options[prefix]" type="hidden" value="last">


### PR DESCRIPTION
# Description
Pages like this [https://www.thedyslexiashop.co.uk/collections/Time/Game](https://www.thedyslexiashop.co.uk/collections/Time/Game) are built from tags within a collection. TDS wanted the product count removed from here.

I am using the following to check if the page is a tag powered page and wrapping it round the product count element:
`
{% unless current_tags %}
{% endunless %}
`

# Test
This URL will have the product count [https://o1hgkr0begdxii7z-65365606649.shopifypreview.com/collections/Time](https://o1hgkr0begdxii7z-65365606649.shopifypreview.com/collections/Time)

This URL will not have the product count [https://o1hgkr0begdxii7z-65365606649.shopifypreview.com/collections/Time/Game](https://o1hgkr0begdxii7z-65365606649.shopifypreview.com/collections/Time/Game)