### PR TITLE
ScrollIntoView removed

### DIFF
--- a/assets/media-gallery.js
+++ b/assets/media-gallery.js
@@ -40,12 +40,7 @@ if (!customElements.get('media-gallery')) {
 
       this.preventStickyHeader();
       window.setTimeout(() => {
-        if (this.elements.thumbnails) {
           activeMedia.parentElement.scrollTo({ left: activeMedia.offsetLeft });
-        }
-        if (this.dataset.desktopLayout === 'stacked') {
-          activeMedia.scrollIntoView({behavior: 'smooth'});
-        }
       });
       this.playActiveMedia(activeMedia);
 


### PR DESCRIPTION
We do not need scrollIntoView because it is scrolling down. Instead the products will have the same functionality with or without thumbnails.